### PR TITLE
refactor: InvalidGrantTypeException 반환 코드 406으로 변경

### DIFF
--- a/src/main/java/com/dku/council/domain/oauth/exception/InvalidGrantTypeException.java
+++ b/src/main/java/com/dku/council/domain/oauth/exception/InvalidGrantTypeException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidGrantTypeException extends LocalizedMessageException {
     public InvalidGrantTypeException(String grantType) {
-        super(HttpStatus.BAD_REQUEST, "invalid.oauth-grant-type: " + grantType);
+        super(HttpStatus.NOT_ACCEPTABLE, "invalid.oauth-grant-type: " + grantType);
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthClientIdException.java
+++ b/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthClientIdException.java
@@ -6,6 +6,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidOauthClientIdException extends LocalizedMessageException {
     public InvalidOauthClientIdException(String clientId) {
-        super(HttpStatus.BAD_REQUEST, "invalid.oauth-client-id: " + clientId);
+        super(HttpStatus.NOT_ACCEPTABLE, "invalid.oauth-client-id: " + clientId);
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthRedirectUriException.java
+++ b/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthRedirectUriException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidOauthRedirectUriException extends LocalizedMessageException {
     public InvalidOauthRedirectUriException(String redirectUri) {
-        super(HttpStatus.BAD_REQUEST, "invalid.oauth-redirect-uri: ", redirectUri);
+        super(HttpStatus.NOT_ACCEPTABLE, "invalid.oauth-redirect-uri: ", redirectUri);
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthResponseTypeException.java
+++ b/src/main/java/com/dku/council/domain/oauth/exception/InvalidOauthResponseTypeException.java
@@ -5,6 +5,6 @@ import org.springframework.http.HttpStatus;
 
 public class InvalidOauthResponseTypeException extends LocalizedMessageException {
     public InvalidOauthResponseTypeException(String responseType) {
-        super(HttpStatus.BAD_REQUEST, "invalid.oauth-response-type", responseType);
+        super(HttpStatus.NOT_ACCEPTABLE, "invalid.oauth-response-type", responseType);
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
@@ -2,6 +2,8 @@ package com.dku.council.domain.oauth.model.dto.request;
 
 import lombok.Getter;
 
+import static com.dku.council.domain.oauth.model.entity.HashAlgorithm.SHA256;
+
 @Getter
 public class OauthInfo {
     private final String clientId;
@@ -11,7 +13,8 @@ public class OauthInfo {
     private final String scope;
     private final String responseType;
 
-    private OauthInfo(String clientId, String redirectUri, String codeChallenge, String codeChallengeMethod, String scope, String responseType) {
+    private OauthInfo(String clientId, String redirectUri, String codeChallenge,
+                      String codeChallengeMethod, String scope, String responseType) {
         this.clientId = clientId;
         this.redirectUri = redirectUri;
         this.codeChallenge = codeChallenge;
@@ -20,7 +23,11 @@ public class OauthInfo {
         this.responseType = responseType;
     }
 
-    public static OauthInfo of(String clientId, String redirectUri, String codeChallenge, String codeChallengeMethod, String scope, String responseType) {
+    public static OauthInfo of(String clientId, String redirectUri, String codeChallenge,
+                               String codeChallengeMethod, String scope, String responseType) {
+        if (codeChallengeMethod == null) {
+            codeChallengeMethod = SHA256.getShortenedAlgorithm();
+        }
         return new OauthInfo(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, responseType);
     }
 

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthLoginRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthLoginRequest.java
@@ -5,6 +5,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 
 @Getter
@@ -27,6 +28,7 @@ public class OauthLoginRequest {
     @NotBlank(message = "codeChallenge를 입력해주세요.")
     private final String codeChallenge;
 
+    @Nullable
     private final String codeChallengeMethod;
 
     @NotBlank(message = "scope를 입력해주세요.")
@@ -40,6 +42,6 @@ public class OauthLoginRequest {
     }
 
     public OauthInfo toOauthInfo() {
-        return OauthInfo.of(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope,  responseType);
+        return OauthInfo.of(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, responseType);
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
@@ -1,6 +1,8 @@
 package com.dku.council.domain.oauth.model.dto.request;
 
 import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import javax.validation.constraints.NotBlank;
 
@@ -47,5 +49,16 @@ public class OauthRequest {
     public static OauthRequest of(String codeChallenge, String clientId,
                                   String redirectUri, String responseType, String scope) {
         return new OauthRequest(codeChallenge, clientId, redirectUri, responseType, scope);
+    }
+
+    public MultiValueMap<String, String> toQueryParams() {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("code_challenge", codeChallenge);
+        queryParams.add("code_challenge_method", codeChallengeMethod);
+        queryParams.add("client_id", clientId);
+        queryParams.add("redirect_uri", redirectUri);
+        queryParams.add("response_type", responseType);
+        queryParams.add("scope", scope);
+        return queryParams;
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -49,6 +49,7 @@ public class OauthService {
         oauthClient.checkRedirectUri(redirectUri);
         return UriComponentsBuilder
                 .fromUriString(LOGIN_URL)
+                .queryParams(oauthRequest.toQueryParams())
                 .toUriString();
     }
 

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -91,13 +91,14 @@ public class OauthService {
     }
 
     private String getCodeChallengeMethod(String codeChallengeMethod) {
+        if (codeChallengeMethod == null) {
+            return HashAlgorithm.SHA256.getAlgorithm();
+        }
         if (Objects.equals(codeChallengeMethod, HashAlgorithm.SHA1.getShortenedAlgorithm())) {
             codeChallengeMethod = HashAlgorithm.SHA1.getAlgorithm();
-        }
-        if (Objects.equals(codeChallengeMethod, HashAlgorithm.SHA256.getShortenedAlgorithm())) {
+        } else if (Objects.equals(codeChallengeMethod, HashAlgorithm.SHA256.getShortenedAlgorithm())) {
             codeChallengeMethod = HashAlgorithm.SHA256.getAlgorithm();
-        }
-        if (Objects.equals(codeChallengeMethod, HashAlgorithm.SHA512.getShortenedAlgorithm())) {
+        } else if (Objects.equals(codeChallengeMethod, HashAlgorithm.SHA512.getShortenedAlgorithm())) {
             codeChallengeMethod = HashAlgorithm.SHA512.getAlgorithm();
         }
         return codeChallengeMethod;

--- a/src/main/java/com/dku/council/global/config/WebConfig.java
+++ b/src/main/java/com/dku/council/global/config/WebConfig.java
@@ -45,7 +45,8 @@ public class WebConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins(parseCorsList(corsList))
                 .allowedHeaders("*")
-                .allowedMethods("*");
+                .allowedMethods("*")
+                .allowCredentials(true);
     }
 
     private static String[] parseCorsList(String corsList) {

--- a/src/test/java/com/dku/council/domain/oauth/model/dto/request/OauthInfoTest.java
+++ b/src/test/java/com/dku/council/domain/oauth/model/dto/request/OauthInfoTest.java
@@ -53,4 +53,15 @@ class OauthInfoTest {
         assertEquals(scope, payload.getScope());
     }
 
+    @Test
+    void createOauthInfoWithDefaultCodeChallengeMethod() {
+        // given
+        codeChallengeMethod = null;
+
+        // when
+        OauthInfo oauthInfo = OauthInfo.of(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, responseType);
+
+        // then
+        assertEquals("S256", oauthInfo.getCodeChallengeMethod());
+    }
 }


### PR DESCRIPTION
### issue 번호
ex) #59

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[] 기능 추가
-[] 기능 삭제
-[v] 버그 수정
-[] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
- 잘못된 입력값에 따른 Exception 반환 코드 변경
- codeChallengeMethod null일 때, sha256으로 초기화
- /oauth/authrize 리다이렉트 url에 param 추가
- allowCredentials(true)로 요청에 인증과 관련된 정보를 담을 수 있게 함