### PR TITLE
refactor: oauth로그인 시 첫 로그인이라면 약관 동의 페이지로 리다이렉트

### DIFF
--- a/src/main/java/com/dku/council/domain/oauth/controller/OauthController.java
+++ b/src/main/java/com/dku/council/domain/oauth/controller/OauthController.java
@@ -23,7 +23,7 @@ public class OauthController {
                                   @RequestParam String clientId,
                                   @RequestParam String redirectUri,
                                   @RequestParam String responseType,
-                                  @RequestParam String scope) {
+                                  @RequestParam(required = false) String scope) {
         OauthRequest request = OauthRequest.of(codeChallenge, codeChallengeMethod, clientId,
                 redirectUri, responseType, scope);
         String uri = oauthService.authorize(request);

--- a/src/main/java/com/dku/council/domain/oauth/controller/OauthController.java
+++ b/src/main/java/com/dku/council/domain/oauth/controller/OauthController.java
@@ -2,6 +2,7 @@ package com.dku.council.domain.oauth.controller;
 
 import com.dku.council.domain.oauth.model.dto.request.OauthLoginRequest;
 import com.dku.council.domain.oauth.model.dto.request.OauthRequest;
+import com.dku.council.domain.oauth.model.dto.request.OauthTermsRequest;
 import com.dku.council.domain.oauth.model.dto.request.TokenExchangeRequest;
 import com.dku.council.domain.oauth.model.dto.response.TokenExchangeResponse;
 import com.dku.council.domain.oauth.service.OauthService;
@@ -50,4 +51,9 @@ public class OauthController {
         return ResponseEntity.ok(response);
     }
 
+    @PostMapping("/terms")
+    public RedirectView verifyTerms(@RequestBody OauthTermsRequest request) {
+        String uri = oauthService.verifyTerms(request.getStudentId(), request.toOauthInfo());
+        return new RedirectView(uri);
+    }
 }

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
@@ -1,6 +1,8 @@
 package com.dku.council.domain.oauth.model.dto.request;
 
 import lombok.Getter;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 
 import static com.dku.council.domain.oauth.model.entity.HashAlgorithm.SHA256;
 
@@ -33,6 +35,19 @@ public class OauthInfo {
 
     public OauthCachePayload toCachePayload(Long userId) {
         return OauthCachePayload.of(userId, codeChallenge, codeChallengeMethod, scope);
+    }
+
+    public MultiValueMap<String, String> toQueryParams(String scope, String studentId, String applicationName) {
+        MultiValueMap<String, String> queryParams = new LinkedMultiValueMap<>();
+        queryParams.add("client_id", clientId);
+        queryParams.add("redirect_uri", redirectUri);
+        queryParams.add("response_type", responseType);
+        queryParams.add("code_challenge", codeChallenge);
+        queryParams.add("code_challenge_method", codeChallengeMethod);
+        queryParams.add("scope", scope);
+        queryParams.add("student_id", studentId);
+        queryParams.add("application_name", applicationName);
+        return queryParams;
     }
 
 }

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthInfo.java
@@ -33,7 +33,7 @@ public class OauthInfo {
         return new OauthInfo(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, responseType);
     }
 
-    public OauthCachePayload toCachePayload(Long userId) {
+    public OauthCachePayload toCachePayload(Long userId, String scope) {
         return OauthCachePayload.of(userId, codeChallenge, codeChallengeMethod, scope);
     }
 

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthLoginRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthLoginRequest.java
@@ -31,7 +31,7 @@ public class OauthLoginRequest {
     @Nullable
     private final String codeChallengeMethod;
 
-    @NotBlank(message = "scope를 입력해주세요.")
+    @Nullable
     private final String scope;
 
     @NotBlank(message = "responseType을 입력해주세요.")

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
@@ -59,7 +59,6 @@ public class OauthRequest {
         queryParams.add("client_id", clientId);
         queryParams.add("redirect_uri", redirectUri);
         queryParams.add("response_type", responseType);
-        queryParams.add("scope", scope);
         return queryParams;
     }
 }

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthRequest.java
@@ -4,6 +4,7 @@ import lombok.Getter;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 
+import javax.annotation.Nullable;
 import javax.validation.constraints.NotBlank;
 
 @Getter
@@ -17,7 +18,7 @@ public class OauthRequest {
     private final String redirectUri;
     @NotBlank(message = "responseType을 입력해주세요.")
     private final String responseType;
-    @NotBlank(message = "scope를 입력해주세요.")
+    @Nullable
     private final String scope;
 
     private OauthRequest(String codeChallenge, String codeChallengeMethod, String clientId,

--- a/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthTermsRequest.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/dto/request/OauthTermsRequest.java
@@ -1,0 +1,35 @@
+package com.dku.council.domain.oauth.model.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import javax.validation.constraints.NotBlank;
+
+@Getter
+@AllArgsConstructor
+public class OauthTermsRequest {
+    @NotBlank(message = "학번을 입력해주세요.")
+    @Schema(description = "아이디(학번)", example = "12345678")
+    private final String studentId;
+
+    @NotBlank(message = "clientId를 입력해주세요.")
+    private final String clientId;
+
+    @NotBlank(message = "redirectUri를 입력해주세요.")
+    private final String redirectUri;
+
+    @NotBlank(message = "codeChallenge를 입력해주세요.")
+    private final String codeChallenge;
+
+    private final String codeChallengeMethod;
+
+    private final String scope;
+
+    @NotBlank(message = "responseType을 입력해주세요.")
+    private final String responseType;
+
+    public OauthInfo toOauthInfo() {
+        return OauthInfo.of(clientId, redirectUri, codeChallenge, codeChallengeMethod, scope, responseType);
+    }
+}

--- a/src/main/java/com/dku/council/domain/oauth/model/entity/ConnectionStatus.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/entity/ConnectionStatus.java
@@ -1,0 +1,6 @@
+package com.dku.council.domain.oauth.model.entity;
+
+public enum ConnectionStatus {
+    CONNECTED,
+    DISCONNECTED
+}

--- a/src/main/java/com/dku/council/domain/oauth/model/entity/OauthClient.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/entity/OauthClient.java
@@ -29,16 +29,21 @@ public class OauthClient {
     private String applicationName;
     private String clientSecret;
     private String redirectUri;
+    @Column(length = 1000)
+    private String scope;
 
-    private OauthClient(String clientId, String applicationName, String clientSecret, String redirectUri) {
+    private OauthClient(String clientId, String applicationName, String clientSecret,
+                        String redirectUri, String scope) {
         this.clientId = clientId;
         this.applicationName = applicationName;
         this.clientSecret = clientSecret;
         this.redirectUri = redirectUri;
+        this.scope = scope;
     }
 
-    public static OauthClient of(String clientId, String applicationName, String clientSecret, String redirectUri) {
-        return new OauthClient(clientId, applicationName, clientSecret, redirectUri);
+    public static OauthClient of(String clientId, String applicationName, String clientSecret,
+                                 String redirectUri, String scope) {
+        return new OauthClient(clientId, applicationName, clientSecret, redirectUri, scope);
     }
 
     public void checkClientId(String clientId) {

--- a/src/main/java/com/dku/council/domain/oauth/model/entity/OauthClient.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/entity/OauthClient.java
@@ -28,6 +28,7 @@ public class OauthClient {
     private String clientId;
     private String applicationName;
     private String clientSecret;
+    @Column(length = 1000)
     private String redirectUri;
     @Column(length = 1000)
     private String scope;

--- a/src/main/java/com/dku/council/domain/oauth/model/entity/OauthConnection.java
+++ b/src/main/java/com/dku/council/domain/oauth/model/entity/OauthConnection.java
@@ -1,0 +1,44 @@
+package com.dku.council.domain.oauth.model.entity;
+
+import com.dku.council.global.base.BaseEntity;
+import com.dku.council.domain.user.model.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+import static javax.persistence.FetchType.LAZY;
+import static javax.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class OauthConnection extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = LAZY)
+    private User user;
+
+    @ManyToOne(fetch = LAZY)
+    private OauthClient oauthClient;
+
+    private ConnectionStatus status;
+
+    @Override
+    public Long getId() {
+        return this.id;
+    }
+
+    private OauthConnection(User user, OauthClient oauthClient) {
+        this.user = user;
+        this.oauthClient = oauthClient;
+        this.status = ConnectionStatus.CONNECTED;
+    }
+
+    public static OauthConnection of(User user, OauthClient oauthClient) {
+        return new OauthConnection(user, oauthClient);
+    }
+}

--- a/src/main/java/com/dku/council/domain/oauth/repository/OauthConnectionRepository.java
+++ b/src/main/java/com/dku/council/domain/oauth/repository/OauthConnectionRepository.java
@@ -1,0 +1,13 @@
+package com.dku.council.domain.oauth.repository;
+
+import com.dku.council.domain.oauth.model.entity.OauthClient;
+import com.dku.council.domain.oauth.model.entity.OauthConnection;
+import com.dku.council.domain.user.model.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface OauthConnectionRepository extends JpaRepository<OauthConnection, Long> {
+
+    Optional<OauthConnection> findByUserAndOauthClient(User user, OauthClient oauthClient);
+}

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -1,15 +1,11 @@
 package com.dku.council.domain.oauth.service;
 
-import com.dku.council.domain.oauth.exception.InvalidGrantTypeException;
-import com.dku.council.domain.oauth.exception.InvalidOauthResponseTypeException;
-import com.dku.council.domain.oauth.exception.OauthCacheNotFoundException;
-import com.dku.council.domain.oauth.exception.OauthClientNotFoundException;
+import com.dku.council.domain.oauth.exception.*;
 import com.dku.council.domain.oauth.model.dto.request.*;
 import com.dku.council.domain.oauth.model.dto.response.TokenExchangeResponse;
-import com.dku.council.domain.oauth.model.entity.HashAlgorithm;
-import com.dku.council.domain.oauth.model.entity.OauthClient;
-import com.dku.council.domain.oauth.model.entity.OauthResponseType;
+import com.dku.council.domain.oauth.model.entity.*;
 import com.dku.council.domain.oauth.repository.OauthClientRepository;
+import com.dku.council.domain.oauth.repository.OauthConnectionRepository;
 import com.dku.council.domain.oauth.repository.OauthRedisRepository;
 import com.dku.council.domain.oauth.util.CodeChallengeConverter;
 import com.dku.council.domain.user.exception.WrongPasswordException;
@@ -21,12 +17,16 @@ import com.dku.council.global.auth.jwt.AuthenticationToken;
 import com.dku.council.global.auth.jwt.JwtProvider;
 import com.dku.council.global.error.exception.UserNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import java.util.Objects;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -34,6 +34,7 @@ import java.util.Objects;
 public class OauthService {
     private final OauthClientRepository oauthClientRepository;
     private final OauthRedisRepository oauthRedisRepository;
+    private final OauthConnectionRepository oauthConnectionRepository;
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
     private final CodeChallengeConverter codeChallengeConverter;
@@ -48,9 +49,11 @@ public class OauthService {
         String clientId = oauthRequest.getClientId();
         String redirectUri = oauthRequest.getRedirectUri();
         checkResponseType(oauthRequest.getResponseType());
+
         OauthClient oauthClient = getOauthClient(clientId);
         oauthClient.checkClientId(clientId);
         oauthClient.checkRedirectUri(redirectUri);
+
         return UriComponentsBuilder
                 .fromUriString(LOGIN_URL)
                 .queryParams(oauthRequest.toQueryParams())
@@ -60,9 +63,7 @@ public class OauthService {
     @Transactional
     public String login(RequestLoginDto loginInfo, OauthInfo oauthInfo) {
         checkResponseType(oauthInfo.getResponseType());
-        User user = userRepository.findByStudentId(loginInfo.getStudentId())
-                .orElseThrow(UserNotFoundException::new);
-
+        User user = userRepository.findByStudentId(loginInfo.getStudentId()).orElseThrow(UserNotFoundException::new);
         checkPassword(loginInfo.getPassword(), user.getPassword());
 
         OauthClient oauthClient = getOauthClient(oauthInfo.getClientId());
@@ -78,10 +79,9 @@ public class OauthService {
                     .toUriString();
         }
 
-    private void checkPassword(String inputPassword, String userPassword) {
-        if (!passwordEncoder.matches(inputPassword, userPassword)) {
-            throw new WrongPasswordException();
-        }
+        return redirectWithAuthCode(oauthInfo, user, oauthClient);
+    }
+
     @Transactional
     public String verifyTerms(String studentId, OauthInfo oauthInfo) {
         checkResponseType(oauthInfo.getResponseType());
@@ -95,14 +95,15 @@ public class OauthService {
         checkGrantType(target.getGrantType());
         OauthClient oauthClient = getOauthClient(clientInfo.getClientId());
         oauthClient.checkClientSecret(clientInfo.getClientSecret());
-        oauthClient.checkRedirectUri(clientInfo.getRedirectUri());
+
         OauthCachePayload payload = getPayload(target);
         String codeVerifier = target.getCodeVerifier();
         String codeChallengeMethod = getCodeChallengeMethod(payload.getCodeChallengeMethod());
         checkCodeChallenge(codeVerifier, codeChallengeMethod, payload);
-        User user = userRepository.findById(payload.getUserId())
-                .orElseThrow(UserNotFoundException::new);
+
+        User user = userRepository.findById(payload.getUserId()).orElseThrow(UserNotFoundException::new);
         AuthenticationToken token = jwtProvider.issue(user);
+
         return TokenExchangeResponse.of(token.getAccessToken(), token.getRefreshToken(), payload.getScope());
     }
 
@@ -128,6 +129,13 @@ public class OauthService {
         OauthConnection connection = connectionOptional.orElse(null);
         return connectionOptional.isEmpty() || connection.getStatus() == ConnectionStatus.DISCONNECTED;
     }
+
+    private void checkPassword(String inputPassword, String userPassword) {
+        if (!passwordEncoder.matches(inputPassword, userPassword)) {
+            throw new WrongPasswordException();
+        }
+    }
+
     private String getCodeChallengeMethod(String codeChallengeMethod) {
         if (codeChallengeMethod == null) {
             return HashAlgorithm.SHA256.getAlgorithm();

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -82,6 +82,12 @@ public class OauthService {
         if (!passwordEncoder.matches(inputPassword, userPassword)) {
             throw new WrongPasswordException();
         }
+    @Transactional
+    public String verifyTerms(String studentId, OauthInfo oauthInfo) {
+        checkResponseType(oauthInfo.getResponseType());
+        User user = userRepository.findByStudentId(studentId).orElseThrow(UserNotFoundException::new);
+        OauthClient oauthClient = getOauthClient(oauthInfo.getClientId());
+        oauthClient.checkRedirectUri(oauthInfo.getRedirectUri());
         return redirectWithAuthCode(oauthInfo, user, oauthClient);
     }
 

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -38,7 +38,10 @@ public class OauthService {
     private final PasswordEncoder passwordEncoder;
     private final CodeChallengeConverter codeChallengeConverter;
     private final JwtProvider jwtProvider;
-    private static final String LOGIN_URL = "https://oauth.danvery.com/signin";
+    @Value("${app.oauth.login.url}")
+    private final String LOGIN_URL;
+    @Value("${app.oauth.terms.url}")
+    private final String TERMS_URL;
     private final String CODE = "code";
 
     public String authorize(OauthRequest oauthRequest) {
@@ -70,6 +73,7 @@ public class OauthService {
                 .toUriString();
     }
                 .queryParam(CODE, authCode)
+                    .fromUriString(TERMS_URL)
 
     private void checkPassword(String inputPassword, String userPassword) {
         if (!passwordEncoder.matches(inputPassword, userPassword)) {
@@ -92,6 +96,7 @@ public class OauthService {
         return TokenExchangeResponse.of(token.getAccessToken(), token.getRefreshToken(), payload.getScope());
     }
 
+                .queryParam(CODE, authCode)
     private String getCodeChallengeMethod(String codeChallengeMethod) {
         if (codeChallengeMethod == null) {
             return HashAlgorithm.SHA256.getAlgorithm();

--- a/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
+++ b/src/main/java/com/dku/council/domain/oauth/service/OauthService.java
@@ -39,6 +39,7 @@ public class OauthService {
     private final CodeChallengeConverter codeChallengeConverter;
     private final JwtProvider jwtProvider;
     private static final String LOGIN_URL = "https://oauth.danvery.com/signin";
+    private final String CODE = "code";
 
     public String authorize(OauthRequest oauthRequest) {
         String clientId = oauthRequest.getClientId();
@@ -66,9 +67,9 @@ public class OauthService {
         oauthRedisRepository.cacheOauth(authCode, cachePayload);
         return UriComponentsBuilder
                 .fromUriString(oauthInfo.getRedirectUri())
-                .queryParam("code", authCode)
                 .toUriString();
     }
+                .queryParam(CODE, authCode)
 
     private void checkPassword(String inputPassword, String userPassword) {
         if (!passwordEncoder.matches(inputPassword, userPassword)) {


### PR DESCRIPTION
### issue 번호
ex) #59

### PR 타입(하나 이상의 PR 타입을 선택해주세요)
-[v] 기능 추가
-[] 기능 삭제
-[] 버그 수정
-[v] 의존성, 환경 변수, 빌드 관련 코드 업데이트

### 작업 사항
- 로그인 페이지로 리다이렉트 될 때, param에 scope 제거
- String 변수 final 변수로 선언하여 사용
- oauth url(login, term)을 @Value로 주입
- user가 어떤 서비스에 연결되어 있는지 확인하기 위해 oauthConnection 엔티티 추가
- 특정 서비스에서 첫 소셜 로그인이라면 약관 동의 페이지로 이동
- 약관 동의 시 다시 원래 이용하려 했던 서비스 url로 리다이렉트